### PR TITLE
Update action.yml node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Actions Deploy warn: Node.js 16 actions are deprecated.